### PR TITLE
Avoid reading in a whole text file into memory

### DIFF
--- a/0_generate/prepare
+++ b/0_generate/prepare
@@ -31,8 +31,8 @@ for TSV in *.tsv; do
     BASE=$(basename "${TSV}" .tsv)
     ${DIR}/split.py                      \
         --seed="${SEED}"                 \
-        --input_path="${TSV}"            \
-        --train_path="${BASE}_train.tsv" \
-        --dev_path="${BASE}_dev.tsv"     \
-        --test_path="${BASE}_test.tsv"
+        --input-path="${TSV}"            \
+        --train-path="${BASE}_train.tsv" \
+        --dev-path="${BASE}_dev.tsv"     \
+        --test-path="${BASE}_test.tsv"
 done


### PR DESCRIPTION
Not sure if it's too late to get this in at this stage -- Instead of reading in a whole text file into memory (which isn't great) and shuffling it, we should create shuffled indices and use them to split a source file into the splits.